### PR TITLE
Add castellated pin header

### DIFF
--- a/pkl_pin_headers.pretty/Pin_Header_Straight_Round_1x01_Castellated.kicad_mod
+++ b/pkl_pin_headers.pretty/Pin_Header_Straight_Round_1x01_Castellated.kicad_mod
@@ -1,0 +1,18 @@
+(module Pin_Header_Straight_Round_1x01_Castellated (layer F.Cu) (tedit 5ED75366)
+  (descr "Through hole pin header with castellation")
+  (tags "pin header")
+  (fp_text reference REF** (at 0 -5.1) (layer F.Fab) hide
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value PH1X1R (at 0 -3.1) (layer F.Fab) hide
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_line (start -1.25 1.25) (end 1.25 1.25) (layer F.CrtYd) (width 0.05))
+  (fp_line (start -1.25 -1.25) (end 1.25 -1.25) (layer F.CrtYd) (width 0.05))
+  (fp_line (start 1.25 -1.25) (end 1.25 1.25) (layer F.CrtYd) (width 0.05))
+  (fp_line (start -1.25 -1.25) (end -1.25 1.25) (layer F.CrtYd) (width 0.05))
+  (pad 1 thru_hole circle (at 0 0) (size 1.524 1.524) (drill 0.9652) (layers *.Cu *.Mask))
+  (pad 1 thru_hole circle (at 0 1.27) (size 1.524 1.524) (drill 0.9652) (layers *.Cu *.Mask))
+  (pad 1 smd rect (at 0 0.635) (size 1.524 1.27) (layers F.Cu F.Mask))
+  (pad 1 smd rect (at 0 0.635) (size 1.524 1.27) (layers B.Cu B.Mask))
+)


### PR DESCRIPTION
Only issue is, the SMD pads that connect the two through-holes can only be placed on top & bottom copper layers, so the inner layers look a bit wonky:

![image](https://user-images.githubusercontent.com/3586264/83616952-48220a80-a53d-11ea-8786-90cf69dd8d8f.png)
VS
![image](https://user-images.githubusercontent.com/3586264/83616995-54a66300-a53d-11ea-92e1-6c6cf06beaa8.png)
